### PR TITLE
Read Etherscan URLs from config file

### DIFF
--- a/.changeset/ten-humans-flash.md
+++ b/.changeset/ten-humans-flash.md
@@ -1,0 +1,5 @@
+---
+'@dethcrypto/eth-sdk': minor
+---
+
+Read custom Etherscan URLs from `"etherscanURLs"` property in config file

--- a/packages/eth-sdk/README.md
+++ b/packages/eth-sdk/README.md
@@ -5,7 +5,7 @@
   <p align="center">The quickest and easiest way to interact with Ethereum</p>
 </p>
 
-<h1>Features ⚡</h1>
+<h2>Features ⚡</h2>
 
 - minimal - just provide addresses of contracts that you wish to interact with
 - easy to use - ABIs will be automatically downloaded from Etherscan
@@ -26,8 +26,6 @@
 - [Examples](#examples)
 - [Motivation and use cases](#motivation-and-use-cases)
 - [State of the project](#state-of-the-project)
-
----
 
 # Installation
 

--- a/packages/eth-sdk/README.md
+++ b/packages/eth-sdk/README.md
@@ -14,23 +14,18 @@
 
 ---
 
-# <<<<<<< HEAD
-
-- [Features ⚡](#features-)
-  > > > > > > > 0a2e054 (Draft configuration reference in README)
-- [<<<<<<< HEAD](#-head)
-  - [Installation](#installation)
-  - [Usage](#usage)
-    - [CLI Options](#cli-options)
-    - [Getting started](#getting-started)
-    - [Configuration](#configuration)
-      - [`contracts`](#contracts)
-      - [`outputPath`](#outputpath)
-      - [`etherscanKey`](#etherscankey)
-  - [Examples](#examples)
-  - [Motivation and use cases](#motivation-and-use-cases)
-  - [Configuration](#configuration-1)
-  - [State of the project](#state-of-the-project)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [CLI Options](#cli-options)
+  - [Getting started](#getting-started)
+  - [Configuration](#configuration)
+    - [`contracts`](#contracts)
+    - [`outputPath`](#outputpath)
+    - [`etherscanKey`](#etherscankey)
+- [Examples](#examples)
+- [Motivation and use cases](#motivation-and-use-cases)
+- [Configuration](#configuration-1)
+- [State of the project](#state-of-the-project)
 
 ---
 

--- a/packages/eth-sdk/README.md
+++ b/packages/eth-sdk/README.md
@@ -151,7 +151,7 @@ A map from network identifier into deeply nested key-value pairs of contract nam
 }
 ```
 
-Supported network identifiers are:
+Predefined network identifiers are:
 
 ```
 "mainnet"            "ropsten"            "rinkeby"
@@ -161,6 +161,8 @@ Supported network identifiers are:
 "optimismKovan"      "polygon"            "polygonMumbai"
 "arbitrumOne"        "arbitrumTestnet"
 ```
+
+You can add your own Etherscan URL 
 
 #### `outputPath`
 
@@ -193,9 +195,11 @@ Etherscan API key.
 ```json
 {
   "etherscanURLs": {
+    "helloworld": "https://api.etherscan.io/api"
+  },
+  "contracts": {
     "helloworld": {
-      "apiURL": "https://api.etherscan.io/api",
-      "browserURL": "https://etherscan.io"
+      // ...
     }
   }
 }

--- a/packages/eth-sdk/README.md
+++ b/packages/eth-sdk/README.md
@@ -14,18 +14,23 @@
 
 ---
 
-- [Installation](#installation)
-- [Usage](#usage)
-  - [CLI Options](#cli-options)
-  - [Getting started](#getting-started)
-  - [Configuration](#configuration)
-    - [`contracts`](#contracts)
-    - [`outputPath`](#outputpath)
-    - [`etherscanKey`](#etherscankey)
-- [Examples](#examples)
-- [Motivation and use cases](#motivation-and-use-cases)
-- [Configuration](#configuration-1)
-- [State of the project](#state-of-the-project)
+# <<<<<<< HEAD
+
+- [Features ⚡](#features-)
+  > > > > > > > 0a2e054 (Draft configuration reference in README)
+- [<<<<<<< HEAD](#-head)
+  - [Installation](#installation)
+  - [Usage](#usage)
+    - [CLI Options](#cli-options)
+    - [Getting started](#getting-started)
+    - [Configuration](#configuration)
+      - [`contracts`](#contracts)
+      - [`outputPath`](#outputpath)
+      - [`etherscanKey`](#etherscankey)
+  - [Examples](#examples)
+  - [Motivation and use cases](#motivation-and-use-cases)
+  - [Configuration](#configuration-1)
+  - [State of the project](#state-of-the-project)
 
 ---
 

--- a/packages/eth-sdk/README.md
+++ b/packages/eth-sdk/README.md
@@ -5,7 +5,7 @@
   <p align="center">The quickest and easiest way to interact with Ethereum</p>
 </p>
 
-<h2>Features ⚡</h2>
+<h1>Features ⚡</h1>
 
 - minimal - just provide addresses of contracts that you wish to interact with
 - easy to use - ABIs will be automatically downloaded from Etherscan
@@ -25,12 +25,11 @@
     - [`etherscanURLs`](#etherscanurls)
 - [Examples](#examples)
 - [Motivation and use cases](#motivation-and-use-cases)
-- [Configuration](#configuration-1)
 - [State of the project](#state-of-the-project)
 
 ---
 
-## Installation
+# Installation
 
 ```
 yarn add --dev @dethcrypto/eth-sdk @dethcrypto/eth-sdk-client
@@ -38,13 +37,13 @@ yarn add --dev @dethcrypto/eth-sdk @dethcrypto/eth-sdk-client
 
 `eth-sdk` uses ethers.js and TypeScript, so these dependencies have to be installed as well.
 
-## Usage
+# Usage
 
 ```bash
 eth-sdk [options]
 ```
 
-### CLI Options
+## CLI Options
 
 Options:
 
@@ -52,7 +51,7 @@ Options:
 
   `eth-sdk` looks for the config file in this directory, and saves downloaded ABIs there.
 
-### Getting started
+## Getting started
 
 `eth-sdk` takes a JSON config file with ethereum addresses and generates a fully type-safe SDK that you can use right
 away. The SDK is an object consisting of ethers.js contracts initialized with ABIs provided by etherscan and with types
@@ -109,7 +108,7 @@ main()
   })
 ```
 
-### Configuration
+## Configuration
 
 `eth-sdk` looks for a file named `config` or `eth-sdk.config` with `.ts`, `.json`, `.js` or `.cjs` extension inside of
 the directory specified by `--path` CLI argument.
@@ -134,7 +133,7 @@ export default defineConfig({
 })
 ```
 
-#### `contracts`
+### `contracts`
 
 A map from network identifier into deeply nested key-value pairs of contract names and addresses.
 
@@ -162,9 +161,9 @@ Predefined network identifiers are:
 "arbitrumOne"        "arbitrumTestnet"
 ```
 
-You can add your own Etherscan URL 
+You can configure your own Etherscan URLs in [`etherscanURLs`](#etherscanurls).
 
-#### `outputPath`
+### `outputPath`
 
 Output directory for generated SDK.
 
@@ -176,7 +175,7 @@ Output directory for generated SDK.
 }
 ```
 
-#### `etherscanKey`
+### `etherscanKey`
 
 Etherscan API key.
 
@@ -188,9 +187,9 @@ Etherscan API key.
 }
 ```
 
-#### `etherscanURLs`
+### `etherscanURLs`
 
-**TODO: Description and better example?**
+Key-value pairs of network identifier and Etherscan API URL to fetch ABIs from.
 
 ```json
 {
@@ -198,14 +197,12 @@ Etherscan API key.
     "helloworld": "https://api.etherscan.io/api"
   },
   "contracts": {
-    "helloworld": {
-      // ...
-    }
+    "helloworld": {}
   }
 }
 ```
 
-## Examples
+# Examples
 
 Check out examples of using `eth-sdk` in [`/examples`][examples] directory.
 
@@ -214,7 +211,7 @@ Check out examples of using `eth-sdk` in [`/examples`][examples] directory.
 
 [examples]: https://github.com/dethcrypto/eth-sdk/tree/master/examples
 
-## Motivation and use cases
+# Motivation and use cases
 
 The primary motivation for the project is reducing the ceremony needed to interact with smart contracts on Ethereum
 while using JavaScript or TypeScript. It takes care of boring parts like ABI management and auto-generates all the
@@ -224,10 +221,7 @@ have type information so your IDE can assist you.
 It works well with all sorts of scripts, backend services, and even frontend apps. Note: If you develop smart contracts
 it's better to use TypeChain directly (especially via HardHat integration).
 
-## Configuration
-
-## State of the project
+# State of the project
 
 The project is in a very experimental stage. Don't hesitate to create an issue / pull request helping to steer the
-vision. Particularly things like input configuration are not set in stone (how should JSON config look like? should we
-support `.yml` etc)
+vision.

--- a/packages/eth-sdk/README.md
+++ b/packages/eth-sdk/README.md
@@ -22,6 +22,7 @@
     - [`contracts`](#contracts)
     - [`outputPath`](#outputpath)
     - [`etherscanKey`](#etherscankey)
+    - [`etherscanURLs`](#etherscanurls)
 - [Examples](#examples)
 - [Motivation and use cases](#motivation-and-use-cases)
 - [Configuration](#configuration-1)
@@ -182,6 +183,21 @@ Etherscan API key.
 ```json
 {
   "etherscanKey": "ZWD4W1GTHISTFYJWONTPWTNXAFWORKB2WW"
+}
+```
+
+#### `etherscanURLs`
+
+**TODO: Description and better example?**
+
+```json
+{
+  "etherscanURLs": {
+    "helloworld": {
+      "apiURL": "https://api.etherscan.io/api",
+      "browserURL": "https://etherscan.io"
+    }
+  }
 }
 ```
 

--- a/packages/eth-sdk/src/abi-management/etherscan/getAbiFromEtherscan.test.ts
+++ b/packages/eth-sdk/src/abi-management/etherscan/getAbiFromEtherscan.test.ts
@@ -22,10 +22,7 @@ describe(getABIFromEtherscan.name, () => {
     const apiKey = 'woop'
 
     const userNetworks: UserEtherscanURLs = {
-      [symbol]: {
-        apiURL: 'https://dethcryptoscan.test/api/v1',
-        browserURL: 'https://dethcryptoscan.test',
-      },
+      [symbol]: 'https://dethcryptoscan.test/api/v1',
     }
 
     const fetch = mockEndpoint()
@@ -44,7 +41,7 @@ const DAI_ADDRESS = parseAddress('0x6B175474E89094C44Da98b954EedeAC495271d0F')
 
 const RETURNED_ABI = ['{{ RETURNED_ABI }}']
 function mockEndpoint() {
-  const fetch: FetchAbi = async (url) => ({
+  const fetch: FetchAbi = async (_url) => ({
     body: JSON.stringify({
       status: '1',
       result: JSON.stringify(RETURNED_ABI),

--- a/packages/eth-sdk/src/abi-management/etherscan/getAbiFromEtherscan.test.ts
+++ b/packages/eth-sdk/src/abi-management/etherscan/getAbiFromEtherscan.test.ts
@@ -1,0 +1,54 @@
+import { expect, mockFn } from 'earljs'
+import { constants } from 'ethers'
+
+import { parseAddress, UserEtherscanURLs } from '../../config'
+import { UserProvidedNetworkSymbol } from '../networks'
+import { FetchAbi, getABIFromEtherscan } from './getAbiFromEtherscan'
+
+describe(getABIFromEtherscan.name, () => {
+  it('fetches from predefined etherscan URL', async () => {
+    const apiKey = '{{ API_KEY }}'
+    const fetch = mockEndpoint()
+    const actual = await getABIFromEtherscan('mainnet', DAI_ADDRESS, apiKey, {}, fetch)
+
+    expect(actual).toEqual(RETURNED_ABI)
+    expect(fetch).toHaveBeenCalledWith([
+      `https://api.etherscan.io/api?module=contract&action=getabi&address=${DAI_ADDRESS}&apikey=${apiKey}`,
+    ])
+  })
+
+  it('fetches from user-specified URL', async () => {
+    const symbol = UserProvidedNetworkSymbol('dethcryptoscan')
+    const apiKey = 'woop'
+
+    const userNetworks: UserEtherscanURLs = {
+      [symbol]: {
+        apiURL: 'https://dethcryptoscan.test/api/v1',
+        browserURL: 'https://dethcryptoscan.test',
+      },
+    }
+
+    const fetch = mockEndpoint()
+
+    const actual = await getABIFromEtherscan(symbol, ADDRESS_ZERO, apiKey, userNetworks, fetch)
+
+    expect(actual).toEqual(RETURNED_ABI)
+    expect(fetch).toHaveBeenCalledWith([
+      `https://dethcryptoscan.test/api/v1?module=contract&action=getabi&address=${ADDRESS_ZERO}&apikey=${apiKey}`,
+    ])
+  })
+})
+
+const ADDRESS_ZERO = parseAddress(constants.AddressZero)
+const DAI_ADDRESS = parseAddress('0x6B175474E89094C44Da98b954EedeAC495271d0F')
+
+const RETURNED_ABI = ['{{ RETURNED_ABI }}']
+function mockEndpoint() {
+  const fetch: FetchAbi = async (url) => ({
+    body: JSON.stringify({
+      status: '1',
+      result: JSON.stringify(RETURNED_ABI),
+    }),
+  })
+  return mockFn(fetch)
+}

--- a/packages/eth-sdk/src/abi-management/etherscan/getAbiFromEtherscan.ts
+++ b/packages/eth-sdk/src/abi-management/etherscan/getAbiFromEtherscan.ts
@@ -1,17 +1,23 @@
-import got from 'got'
+import got, { Response } from 'got'
 
 import { Address } from '../../config'
-import { symbolToNetworkId } from '../networks'
-import { EtherscanURLs, networkIDtoEndpoints } from './urls'
+import { NetworkSymbol, symbolToNetworkId, UserProvidedNetworkSymbol } from '../networks'
+import { EtherscanURLs, networkIDtoEndpoints, UserEtherscanURLs } from './urls'
 
-export async function getABIFromEtherscan(networkSymbol: string, address: Address, apiKey: string): Promise<any> {
-  const etherscanUrls = getEtherscanLinkFromNetworkSymbol(networkSymbol)
+export async function getABIFromEtherscan(
+  networkSymbol: NetworkSymbol,
+  address: Address,
+  apiKey: string,
+  userNetworks: UserEtherscanURLs,
+  fetch: FetchAbi = got,
+): Promise<object> {
+  const etherscanUrls = getEtherscanLinkFromNetworkSymbol(networkSymbol, userNetworks)
   if (!etherscanUrls) {
     throw new Error(`Can't find network info for ${networkSymbol}`)
   }
 
   const url = `${etherscanUrls.apiURL}?module=contract&action=getabi&address=${address}&apikey=${apiKey}`
-  const rawResponse = await got(url)
+  const rawResponse = await fetch(url)
   // @todo error handling for incorrect api keys
   const jsonResponse = JSON.parse(rawResponse.body)
 
@@ -24,13 +30,27 @@ export async function getABIFromEtherscan(networkSymbol: string, address: Addres
   return abi
 }
 
-function getEtherscanLinkFromNetworkSymbol(networkSymbol: string): EtherscanURLs | undefined {
-  const networkId = symbolToNetworkId[networkSymbol]
-  if (networkId === undefined) {
-    return undefined
+/**
+ * @internal exported for tests only
+ */
+export type FetchAbi = (url: string) => Promise<Pick<Response<string>, 'body'>>
+
+function getEtherscanLinkFromNetworkSymbol(
+  networkSymbol: NetworkSymbol,
+  userNetworks: UserEtherscanURLs,
+): EtherscanURLs | undefined {
+  if (isUserProvidedNetwork(networkSymbol, userNetworks)) {
+    return userNetworks[networkSymbol]
   }
 
-  const etherscanUrls = networkIDtoEndpoints[networkId]
+  const networkId = symbolToNetworkId[networkSymbol]
 
-  return etherscanUrls
+  return networkId && networkIDtoEndpoints[networkId]
+}
+
+function isUserProvidedNetwork(
+  symbol: NetworkSymbol,
+  userNetworks: UserEtherscanURLs,
+): symbol is UserProvidedNetworkSymbol {
+  return symbol in userNetworks
 }

--- a/packages/eth-sdk/src/abi-management/etherscan/getAbiFromEtherscan.ts
+++ b/packages/eth-sdk/src/abi-management/etherscan/getAbiFromEtherscan.ts
@@ -1,8 +1,9 @@
 import got, { Response } from 'got'
 
-import { Address } from '../../config'
+import type { Address } from '../../config'
+import type { URLString } from '../../utils/utility-types'
 import { NetworkSymbol, symbolToNetworkId, UserProvidedNetworkSymbol } from '../networks'
-import { EtherscanURLs, networkIDtoEndpoints, UserEtherscanURLs } from './urls'
+import { networkIDtoEndpoints, UserEtherscanURLs } from './urls'
 
 export async function getABIFromEtherscan(
   networkSymbol: NetworkSymbol,
@@ -11,12 +12,12 @@ export async function getABIFromEtherscan(
   userNetworks: UserEtherscanURLs,
   fetch: FetchAbi = got,
 ): Promise<object> {
-  const etherscanUrls = getEtherscanLinkFromNetworkSymbol(networkSymbol, userNetworks)
-  if (!etherscanUrls) {
+  const apiUrl = getEtherscanLinkFromNetworkSymbol(networkSymbol, userNetworks)
+  if (!apiUrl) {
     throw new Error(`Can't find network info for ${networkSymbol}`)
   }
 
-  const url = `${etherscanUrls.apiURL}?module=contract&action=getabi&address=${address}&apikey=${apiKey}`
+  const url = `${apiUrl}?module=contract&action=getabi&address=${address}&apikey=${apiKey}`
   const rawResponse = await fetch(url)
   // @todo error handling for incorrect api keys
   const jsonResponse = JSON.parse(rawResponse.body)
@@ -38,7 +39,7 @@ export type FetchAbi = (url: string) => Promise<Pick<Response<string>, 'body'>>
 function getEtherscanLinkFromNetworkSymbol(
   networkSymbol: NetworkSymbol,
   userNetworks: UserEtherscanURLs,
-): EtherscanURLs | undefined {
+): URLString | undefined {
   if (isUserProvidedNetwork(networkSymbol, userNetworks)) {
     return userNetworks[networkSymbol]
   }

--- a/packages/eth-sdk/src/abi-management/etherscan/getAbiFromEtherscan.ts
+++ b/packages/eth-sdk/src/abi-management/etherscan/getAbiFromEtherscan.ts
@@ -31,9 +31,7 @@ export async function getABIFromEtherscan(
   return abi
 }
 
-/**
- * @internal exported for tests only
- */
+/** @internal exported for tests only */
 export type FetchAbi = (url: string) => Promise<Pick<Response<string>, 'body'>>
 
 function getEtherscanLinkFromNetworkSymbol(

--- a/packages/eth-sdk/src/abi-management/etherscan/urls.ts
+++ b/packages/eth-sdk/src/abi-management/etherscan/urls.ts
@@ -1,6 +1,7 @@
-import { NetworkID } from '../networks'
+import { NetworkID, UserProvidedNetworkSymbol } from '../networks'
 
-// note: copied from https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-etherscan/src/network/prober.ts
+// #region copied from hardhat-etherscan source
+/** @see https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-etherscan/src/network/prober.ts */
 export interface EtherscanURLs {
   apiURL: string
   browserURL: string
@@ -80,3 +81,7 @@ export const networkIDtoEndpoints: NetworkId2Etherscan = {
     browserURL: 'https://testnet.arbiscan.io/',
   },
 }
+// #endregion copied from hardhat-etherscan source
+
+export interface UserEtherscanURLs extends Record<UserProvidedNetworkSymbol, EtherscanURLs> {}
+export interface UserEtherscanURLsInput extends Record<string, EtherscanURLs> {}

--- a/packages/eth-sdk/src/abi-management/etherscan/urls.ts
+++ b/packages/eth-sdk/src/abi-management/etherscan/urls.ts
@@ -1,87 +1,33 @@
+import type { URLString } from '../../utils/utility-types'
 import { NetworkID, UserProvidedNetworkSymbol } from '../networks'
 
-// #region copied from hardhat-etherscan source
-/** @see https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-etherscan/src/network/prober.ts */
-export interface EtherscanURLs {
-  apiURL: string
-  browserURL: string
-}
+type NetworkId2Etherscan = { [networkID in NetworkID]: URLString }
 
-type NetworkId2Etherscan = {
-  [networkID in NetworkID]: EtherscanURLs
-}
-
+/**
+ * This object is adapted from hardhat-etherscan source.
+ * Refer to the following file to add new predefined networks:
+ *
+ * @see https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-etherscan/src/network/prober.ts
+ */
 export const networkIDtoEndpoints: NetworkId2Etherscan = {
-  [NetworkID.MAINNET]: {
-    apiURL: 'https://api.etherscan.io/api',
-    browserURL: 'https://etherscan.io',
-  },
-  [NetworkID.ROPSTEN]: {
-    apiURL: 'https://api-ropsten.etherscan.io/api',
-    browserURL: 'https://ropsten.etherscan.io',
-  },
-  [NetworkID.RINKEBY]: {
-    apiURL: 'https://api-rinkeby.etherscan.io/api',
-    browserURL: 'https://rinkeby.etherscan.io',
-  },
-  [NetworkID.GOERLI]: {
-    apiURL: 'https://api-goerli.etherscan.io/api',
-    browserURL: 'https://goerli.etherscan.io',
-  },
-  [NetworkID.KOVAN]: {
-    apiURL: 'https://api-kovan.etherscan.io/api',
-    browserURL: 'https://kovan.etherscan.io',
-  },
-  [NetworkID.BSC]: {
-    apiURL: 'https://api.bscscan.com/api',
-    browserURL: 'https://bscscan.com',
-  },
-  [NetworkID.BSC_TESTNET]: {
-    apiURL: 'https://api-testnet.bscscan.com/api',
-    browserURL: 'https://testnet.bscscan.com',
-  },
-  [NetworkID.HECO]: {
-    apiURL: 'https://api.hecoinfo.com/api',
-    browserURL: 'https://hecoinfo.com',
-  },
-  [NetworkID.HECO_TESTNET]: {
-    apiURL: 'https://api-testnet.hecoinfo.com/api',
-    browserURL: 'https://testnet.hecoinfo.com',
-  },
-  [NetworkID.OPERA]: {
-    apiURL: 'https://api.ftmscan.com/api',
-    browserURL: 'https://ftmscan.com',
-  },
-  [NetworkID.FTM_TESTNET]: {
-    apiURL: 'https://api-testnet.ftmscan.com/api',
-    browserURL: 'https://testnet.ftmscan.com',
-  },
-  [NetworkID.OPTIMISTIC_ETHEREUM]: {
-    apiURL: 'https://api-optimistic.etherscan.io/api',
-    browserURL: 'https://optimistic.etherscan.io/',
-  },
-  [NetworkID.OPTIMISTIC_KOVAN]: {
-    apiURL: 'https://api-kovan-optimistic.etherscan.io/api',
-    browserURL: 'https://kovan-optimistic.etherscan.io/',
-  },
-  [NetworkID.POLYGON]: {
-    apiURL: 'https://api.polygonscan.com/api',
-    browserURL: 'https://polygonscan.com',
-  },
-  [NetworkID.POLYGON_MUMBAI]: {
-    apiURL: 'https://api-testnet.polygonscan.com/api',
-    browserURL: 'https://mumbai.polygonscan.com/',
-  },
-  [NetworkID.ARBITRUM_ONE]: {
-    apiURL: 'https://api.arbiscan.io/api',
-    browserURL: 'https://arbiscan.io/',
-  },
-  [NetworkID.ARBITRUM_TESTNET]: {
-    apiURL: 'https://api-testnet.arbiscan.io/api',
-    browserURL: 'https://testnet.arbiscan.io/',
-  },
+  [NetworkID.MAINNET]: 'https://api.etherscan.io/api',
+  [NetworkID.ROPSTEN]: 'https://api-ropsten.etherscan.io/api',
+  [NetworkID.RINKEBY]: 'https://api-rinkeby.etherscan.io/api',
+  [NetworkID.GOERLI]: 'https://api-goerli.etherscan.io/api',
+  [NetworkID.KOVAN]: 'https://api-kovan.etherscan.io/api',
+  [NetworkID.BSC]: 'https://api.bscscan.com/api',
+  [NetworkID.BSC_TESTNET]: 'https://api-testnet.bscscan.com/api',
+  [NetworkID.HECO]: 'https://api.hecoinfo.com/api',
+  [NetworkID.HECO_TESTNET]: 'https://api-testnet.hecoinfo.com/api',
+  [NetworkID.OPERA]: 'https://api.ftmscan.com/api',
+  [NetworkID.FTM_TESTNET]: 'https://api-testnet.ftmscan.com/api',
+  [NetworkID.OPTIMISTIC_ETHEREUM]: 'https://api-optimistic.etherscan.io/api',
+  [NetworkID.OPTIMISTIC_KOVAN]: 'https://api-kovan-optimistic.etherscan.io/api',
+  [NetworkID.POLYGON]: 'https://api.polygonscan.com/api',
+  [NetworkID.POLYGON_MUMBAI]: 'https://api-testnet.polygonscan.com/api',
+  [NetworkID.ARBITRUM_ONE]: 'https://api.arbiscan.io/api',
+  [NetworkID.ARBITRUM_TESTNET]: 'https://api-testnet.arbiscan.io/api',
 }
-// #endregion copied from hardhat-etherscan source
 
-export interface UserEtherscanURLs extends Record<UserProvidedNetworkSymbol, EtherscanURLs> {}
-export interface UserEtherscanURLsInput extends Record<string, EtherscanURLs> {}
+export interface UserEtherscanURLs extends Record<UserProvidedNetworkSymbol, URLString> {}
+export interface UserEtherscanURLsInput extends Record<string, URLString> {}

--- a/packages/eth-sdk/src/abi-management/index.test.ts
+++ b/packages/eth-sdk/src/abi-management/index.test.ts
@@ -3,8 +3,7 @@ import { expect, mockFn } from 'earljs'
 import { mockFilesystem } from '../../test/filesystemMock'
 import { parseAddress } from '../config'
 import { EthSdkCtx } from '../types'
-import { gatherABIs } from './index'
-import { GetAbi } from './types'
+import { gatherABIs, GetAbi } from './index'
 
 const fs = mockFilesystem({})
 
@@ -15,7 +14,7 @@ describe(gatherABIs.name, () => {
 
     expect(fs.test.isDirectory('outputPath/abis/kovan')).toEqual(true)
     expect(fs.test.readJson('outputPath/abis/kovan/dai.json')).toEqual(abiFixtures)
-    expect(getAbiMock).toHaveBeenCalledWith(['kovan', contractsFixture.kovan.dai, etherscanKeyFixture])
+    expect(getAbiMock).toHaveBeenCalledWith(['kovan', contractsFixture.kovan.dai, etherscanKeyFixture, {}])
   })
 })
 
@@ -46,6 +45,7 @@ const ctxFixture: EthSdkCtx = {
     outputPath: 'outputPath',
     contracts: contractsFixture,
     etherscanKey: etherscanKeyFixture,
+    etherscanURLs: {},
   },
   fs,
 }

--- a/packages/eth-sdk/src/abi-management/index.ts
+++ b/packages/eth-sdk/src/abi-management/index.ts
@@ -1,11 +1,21 @@
 import debug from 'debug'
 import { dirname, join } from 'path'
 
+import { Address } from '../config'
 import { traverseContractsMap } from '../config/traverse'
 import { EthSdkCtx } from '../types'
 import { getABIFromEtherscan } from './etherscan/getAbiFromEtherscan'
-import { GetAbi } from './types'
+import type { UserEtherscanURLs } from './etherscan/urls'
+import type { NetworkSymbol } from './networks'
+
 const d = debug('@dethcrypto/eth-sdk:abi')
+
+export type GetAbi = (
+  network: NetworkSymbol,
+  address: Address,
+  apiKey: string,
+  userNetworks: UserEtherscanURLs,
+) => Promise<object>
 
 export async function gatherABIs(ctx: EthSdkCtx, getAbi: GetAbi = getABIFromEtherscan) {
   const { config, fs } = ctx
@@ -16,7 +26,7 @@ export async function gatherABIs(ctx: EthSdkCtx, getAbi: GetAbi = getABIFromEthe
 
     if (!fs.exists(fullAbiPath)) {
       d('ABI doesnt exist already. Querying etherscan')
-      const abi = await getAbi(network, address, config.etherscanKey)
+      const abi = await getAbi(network, address, config.etherscanKey, config.etherscanURLs)
       await fs.ensureDir(dirname(fullAbiPath))
       await fs.write(fullAbiPath, JSON.stringify(abi))
     }

--- a/packages/eth-sdk/src/abi-management/networks.ts
+++ b/packages/eth-sdk/src/abi-management/networks.ts
@@ -1,5 +1,5 @@
 import { invert } from 'lodash'
-import { SafeDictionary } from 'ts-essentials'
+import { Opaque, SafeDictionary } from 'ts-essentials'
 
 // note: copied from https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-etherscan/src/network/prober.ts
 export enum NetworkID {
@@ -48,6 +48,11 @@ export const networkIDtoSymbol = {
   [NetworkID.ARBITRUM_TESTNET]: 'arbitrumTestnet',
 } as const
 
-export type NetworkSymbol = typeof networkIDtoSymbol[keyof typeof networkIDtoSymbol]
+export type UserProvidedNetworkSymbol = Opaque<string, 'UserProvidedNetworkSymbol'>
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const UserProvidedNetworkSymbol = (s: string): UserProvidedNetworkSymbol => s as UserProvidedNetworkSymbol
 
-export const symbolToNetworkId: SafeDictionary<NetworkID, string> = invert(networkIDtoSymbol) as any
+export type PredefinedNetworkSymbol = typeof networkIDtoSymbol[keyof typeof networkIDtoSymbol]
+export type NetworkSymbol = UserProvidedNetworkSymbol | PredefinedNetworkSymbol
+
+export const symbolToNetworkId: SafeDictionary<NetworkID, PredefinedNetworkSymbol> = invert(networkIDtoSymbol) as any

--- a/packages/eth-sdk/src/abi-management/types.ts
+++ b/packages/eth-sdk/src/abi-management/types.ts
@@ -1,3 +1,0 @@
-import { Address } from '../config'
-
-export type GetAbi = (network: string, address: Address, apiKey: string) => Promise<object>

--- a/packages/eth-sdk/src/config/readConfig.test.ts
+++ b/packages/eth-sdk/src/config/readConfig.test.ts
@@ -16,6 +16,7 @@ const configFixture: EthSdkConfig = {
   contracts: contractsFixture,
   outputPath: './node_modules/.dethcrypto/eth-sdk-client',
   etherscanKey: 'CONFIG_ETHERSCAN_KEY',
+  etherscanURLs: {},
 }
 // #endregion fixtures
 
@@ -71,6 +72,7 @@ describe('readConfig', () => {
       },
       outputPath: './eth-sdk/client',
       etherscanKey: expect.stringMatching(''),
+      etherscanURLs: {},
     })
   })
 

--- a/packages/eth-sdk/src/config/readConfig.ts
+++ b/packages/eth-sdk/src/config/readConfig.ts
@@ -1,8 +1,7 @@
 import { extname } from 'path'
 
 import { makeError } from '../utils/makeError'
-import { parseEthSdkConfig } from '.'
-import { EthSdkConfig } from './types'
+import { EthSdkConfig, parseEthSdkConfig } from './types'
 
 export async function readConfig(filePath: string, requireJs: (id: string) => unknown): Promise<EthSdkConfig> {
   const extension = extname(filePath)

--- a/packages/eth-sdk/src/config/types.test.ts
+++ b/packages/eth-sdk/src/config/types.test.ts
@@ -46,6 +46,7 @@ describe('config types', () => {
         contracts: schema.contracts as any,
         outputPath: expect.stringMatching(''),
         etherscanKey: expect.stringMatching(''),
+        etherscanURLs: {},
       })
     })
 

--- a/packages/eth-sdk/src/config/types.ts
+++ b/packages/eth-sdk/src/config/types.ts
@@ -2,8 +2,11 @@ import type { Opaque } from 'ts-essentials'
 import type { ZodString, ZodTypeDef } from 'zod'
 import { z } from 'zod'
 
+import type { UserEtherscanURLs, UserEtherscanURLsInput } from '../abi-management/etherscan/urls'
 import { networkIDtoSymbol, NetworkSymbol, symbolToNetworkId } from '../abi-management/networks'
 import { NestedDict } from '../utils/utility-types'
+
+export type { UserEtherscanURLs, UserEtherscanURLsInput }
 
 const DEFAULT_ETHERSCAN_KEY = 'WW2B6KB1FAXNTWP8EJQJYFTK1CMG1W4DWZ'
 const DEFAULT_OUTPUT_PATH = './node_modules/.dethcrypto/eth-sdk-client'
@@ -48,11 +51,16 @@ export const ethSdKContractsSchema: z.ZodSchema<EthSdkContracts, ZodTypeDef, Eth
   nestedAddressesSchema,
 )
 
+const etherscanURLsSchema: z.ZodSchema<UserEtherscanURLs, ZodTypeDef, UserEtherscanURLsInput> = z.record(
+  z.string(),
+) as any
+
 const ethSdkConfigSchema = z
   .object({
     contracts: ethSdKContractsSchema,
     outputPath: z.string().default(DEFAULT_OUTPUT_PATH),
     etherscanKey: z.string().default(DEFAULT_ETHERSCAN_KEY),
+    etherscanURLs: etherscanURLsSchema.default({}),
   })
   .strict()
 

--- a/packages/eth-sdk/src/index.ts
+++ b/packages/eth-sdk/src/index.ts
@@ -5,8 +5,9 @@ import type {
   EthSdkConfigInput as EthSdkConfig,
   EthSdkContractsInput as EthSdkContracts,
   NestedAddressesInput as NestedAddresses,
+  UserEtherscanURLsInput as EtherscanURLs,
 } from './config'
 
-export type { Address, EthSdkConfig, EthSdkContracts, NestedAddresses }
+export type { Address, EtherscanURLs, EthSdkConfig, EthSdkContracts, NestedAddresses }
 
 export const defineConfig = (config: EthSdkConfig) => config

--- a/packages/eth-sdk/src/utils/utility-types.ts
+++ b/packages/eth-sdk/src/utils/utility-types.ts
@@ -1,3 +1,5 @@
 export interface NestedDict<TValue> {
   [name: string]: TValue | NestedDict<TValue>
 }
+
+export type URLString = `http${string}`

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,12 +1017,7 @@ acorn-walk@^8.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^7.4.0:
-  version "7.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
-  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
-
-acorn@^8.4.1:
+acorn@^8.4.1, acorn@^8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
   integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
@@ -1052,16 +1047,6 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.1:
-  version "8.6.3"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.3.tgz#11a66527761dc3e9a3845ea775d2d3c0414e8764"
-  integrity sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==
-  dependencies:
-    fast-deep-equal "^3.1.1"
-    json-schema-traverse "^1.0.0"
-    require-from-string "^2.0.2"
-    uri-js "^4.2.2"
-
 ansi-align@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
@@ -1088,11 +1073,6 @@ ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
-
-ansi-regex@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
-  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
@@ -1209,11 +1189,6 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
-
-astral-regex@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
-  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 atob@^2.1.2:
   version "2.1.2"
@@ -1681,7 +1656,7 @@ csv@^5.3.1:
     csv-stringify "^5.6.5"
     stream-transform "^2.1.3"
 
-debug@4.3.2, debug@^4.0.1, debug@^4.3.2:
+debug@4.3.2, debug@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -2017,12 +1992,13 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-utils@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
-  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+eslint-scope@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-6.0.0.tgz#9cf45b13c5ac8f3d4c50f46a5121f61b3e318978"
+  integrity sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==
   dependencies:
-    eslint-visitor-keys "^1.1.0"
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
 
 eslint-utils@^3.0.0:
   version "3.0.0"
@@ -2030,11 +2006,6 @@ eslint-utils@^3.0.0:
   integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
   dependencies:
     eslint-visitor-keys "^2.0.0"
-
-eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
-  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
 eslint-visitor-keys@^2.0.0:
   version "2.0.0"
@@ -2092,14 +2063,14 @@ eslint@^7:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^7.3.0, espree@^7.3.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
-  integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
+espree@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-9.0.0.tgz#e90a2965698228502e771c7a58489b1a9d107090"
+  integrity sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==
   dependencies:
-    acorn "^7.4.0"
+    acorn "^8.5.0"
     acorn-jsx "^5.3.1"
-    eslint-visitor-keys "^1.3.0"
+    eslint-visitor-keys "^3.0.0"
 
 esprima@^4.0.0:
   version "4.0.1"
@@ -2524,7 +2495,14 @@ glob-parent@^5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^5.1.2, glob-parent@~5.1.2:
+glob-parent@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
+
+glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -3264,7 +3242,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0:
+js-yaml@4.1.0, js-yaml@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -3301,11 +3279,6 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
-
-json-schema-traverse@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
-  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -3419,11 +3392,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.clonedeep@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
-
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -3433,11 +3401,6 @@ lodash.startcase@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.startcase/-/lodash.startcase-4.4.0.tgz#9436e34ed26093ed7ffae1936144350915d9add8"
   integrity sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg=
-
-lodash.truncate@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
-  integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
 lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.15"
@@ -4195,7 +4158,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexpp@^3.1.0, regexpp@^3.2.0:
+regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
@@ -4219,11 +4182,6 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
-
-require-from-string@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
-  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 require-main-filename@^2.0.0:
   version "2.0.0"
@@ -4424,15 +4382,6 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-slice-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
-  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
-  dependencies:
-    ansi-styles "^4.0.0"
-    astral-regex "^2.0.0"
-    is-fullwidth-code-point "^3.0.0"
-
 smartwrap@^1.2.3:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/smartwrap/-/smartwrap-1.2.5.tgz#45ee3e09ac234e5f7f17c16e916f511834f3cd23"
@@ -4605,15 +4554,6 @@ string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
 string.prototype.trimend@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
@@ -4657,13 +4597,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -4714,18 +4647,6 @@ supports-color@^7.1.0:
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
   dependencies:
     has-flag "^4.0.0"
-
-table@^6.0.9:
-  version "6.7.2"
-  resolved "https://registry.yarnpkg.com/table/-/table-6.7.2.tgz#a8d39b9f5966693ca8b0feba270a78722cbaf3b0"
-  integrity sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==
-  dependencies:
-    ajv "^8.0.1"
-    lodash.clonedeep "^4.5.0"
-    lodash.truncate "^4.4.2"
-    slice-ansi "^4.0.0"
-    string-width "^4.2.3"
-    strip-ansi "^6.0.1"
 
 term-size@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1017,7 +1017,12 @@ acorn-walk@^8.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.4.1, acorn@^8.5.0:
+acorn@^7.4.0:
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.4.1:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
   integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
@@ -1047,6 +1052,16 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+ajv@^8.0.1:
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.3.tgz#11a66527761dc3e9a3845ea775d2d3c0414e8764"
+  integrity sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.2.2"
+
 ansi-align@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
@@ -1073,6 +1088,11 @@ ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
 ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
@@ -1189,6 +1209,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+astral-regex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
+  integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
 atob@^2.1.2:
   version "2.1.2"
@@ -1656,7 +1681,7 @@ csv@^5.3.1:
     csv-stringify "^5.6.5"
     stream-transform "^2.1.3"
 
-debug@4.3.2, debug@^4.3.2:
+debug@4.3.2, debug@^4.0.1, debug@^4.3.2:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -1992,13 +2017,12 @@ eslint-scope@^5.1.1:
     esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
-eslint-scope@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-6.0.0.tgz#9cf45b13c5ac8f3d4c50f46a5121f61b3e318978"
-  integrity sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==
+eslint-utils@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.1.0.tgz#d2de5e03424e707dc10c74068ddedae708741b27"
+  integrity sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
   dependencies:
-    esrecurse "^4.3.0"
-    estraverse "^5.2.0"
+    eslint-visitor-keys "^1.1.0"
 
 eslint-utils@^3.0.0:
   version "3.0.0"
@@ -2006,6 +2030,11 @@ eslint-utils@^3.0.0:
   integrity sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==
   dependencies:
     eslint-visitor-keys "^2.0.0"
+
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
 eslint-visitor-keys@^2.0.0:
   version "2.0.0"
@@ -2063,14 +2092,14 @@ eslint@^7:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-espree@^9.0.0:
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/espree/-/espree-9.0.0.tgz#e90a2965698228502e771c7a58489b1a9d107090"
-  integrity sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==
+espree@^7.3.0, espree@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-7.3.1.tgz#f2df330b752c6f55019f8bd89b7660039c1bbbb6"
+  integrity sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
   dependencies:
-    acorn "^8.5.0"
+    acorn "^7.4.0"
     acorn-jsx "^5.3.1"
-    eslint-visitor-keys "^3.0.0"
+    eslint-visitor-keys "^1.3.0"
 
 esprima@^4.0.0:
   version "4.0.1"
@@ -2495,14 +2524,7 @@ glob-parent@^5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^6.0.1:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
-  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
-  dependencies:
-    is-glob "^4.0.3"
-
-glob-parent@~5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
@@ -3242,7 +3264,7 @@ js-tokens@^4.0.0:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@4.1.0, js-yaml@^4.1.0:
+js-yaml@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
@@ -3279,6 +3301,11 @@ json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
   integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
@@ -3392,6 +3419,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -3401,6 +3433,11 @@ lodash.startcase@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.startcase/-/lodash.startcase-4.4.0.tgz#9436e34ed26093ed7ffae1936144350915d9add8"
   integrity sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg=
+
+lodash.truncate@^4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
+  integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
 lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.15"
@@ -4158,7 +4195,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexpp@^3.2.0:
+regexpp@^3.1.0, regexpp@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.2.0.tgz#0425a2768d8f23bad70ca4b90461fa2f1213e1b2"
   integrity sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==
@@ -4182,6 +4219,11 @@ require-directory@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
   integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 require-main-filename@^2.0.0:
   version "2.0.0"
@@ -4382,6 +4424,15 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
+slice-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-4.0.0.tgz#500e8dd0fd55b05815086255b3195adf2a45fe6b"
+  integrity sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+  dependencies:
+    ansi-styles "^4.0.0"
+    astral-regex "^2.0.0"
+    is-fullwidth-code-point "^3.0.0"
+
 smartwrap@^1.2.3:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/smartwrap/-/smartwrap-1.2.5.tgz#45ee3e09ac234e5f7f17c16e916f511834f3cd23"
@@ -4554,6 +4605,15 @@ string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
+string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
 string.prototype.trimend@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
@@ -4597,6 +4657,13 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"
@@ -4647,6 +4714,18 @@ supports-color@^7.1.0:
   integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
   dependencies:
     has-flag "^4.0.0"
+
+table@^6.0.9:
+  version "6.7.2"
+  resolved "https://registry.yarnpkg.com/table/-/table-6.7.2.tgz#a8d39b9f5966693ca8b0feba270a78722cbaf3b0"
+  integrity sha512-UFZK67uvyNivLeQbVtkiUs8Uuuxv24aSL4/Vil2PJVtMgU8Lx0CYkP12uCGa3kjyQzOSgV1+z9Wkb82fCGsO0g==
+  dependencies:
+    ajv "^8.0.1"
+    lodash.clonedeep "^4.5.0"
+    lodash.truncate "^4.4.2"
+    slice-ansi "^4.0.0"
+    string-width "^4.2.3"
+    strip-ansi "^6.0.1"
 
 term-size@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
### What's changed?

From now on, users can pass API URLs to download ABI from in `"config.etherscanURLs"`. I changed the readme a bit, as we have more configuration options now.

---

- [x] Depends on https://github.com/dethcrypto/eth-sdk/pull/35.
- [x] Needs changeset.
- [x] Needs better readme.
- [x] `browserURL` is unused. Do we need it?

We _could_ also get rid of NetworkId and keep predefined Etherscan URLs as a mapping from network string symbol into URL

```ts
const predefinedUrls = {
  mainnet: "https://api.etherscan.io/api",
  ropsten: "https://api-ropsten.etherscan.io/api",
  // ...
}
```

But let's leave this as a possible future refactor. I have a feeling we might need that id some day, either to automatically user's sdk or to use etherscan URLs imported from another library. 