### PR TITLE
Wrap `got` in `fetchJson`

### DIFF
--- a/packages/eth-sdk/src/abi-management/etherscan/getAbiFromEtherscan.test.ts
+++ b/packages/eth-sdk/src/abi-management/etherscan/getAbiFromEtherscan.test.ts
@@ -2,9 +2,10 @@ import { expect, mockFn } from 'earljs'
 import { constants } from 'ethers'
 
 import { parseAddress, UserEtherscanURLs } from '../../config'
+import { FetchJson } from '../../peripherals/fetchJson'
 import { Abi } from '../../types'
 import { UserProvidedNetworkSymbol } from '../networks'
-import { FetchAbi, getABIFromEtherscan } from './getAbiFromEtherscan'
+import { EtherscanResponse, getABIFromEtherscan } from './getAbiFromEtherscan'
 
 describe(getABIFromEtherscan.name, () => {
   it('fetches from predefined etherscan URL', async () => {
@@ -42,11 +43,10 @@ const DAI_ADDRESS = parseAddress('0x6B175474E89094C44Da98b954EedeAC495271d0F')
 
 const RETURNED_ABI = ['{{ RETURNED_ABI }}'] as Abi
 function mockEndpoint() {
-  const fetch: FetchAbi = async (_url) => ({
-    body: JSON.stringify({
-      status: '1',
-      result: JSON.stringify(RETURNED_ABI),
-    }),
+  const fetch: FetchJson<EtherscanResponse> = async (_url) => ({
+    status: '1',
+    message: 'OK',
+    result: JSON.stringify(RETURNED_ABI),
   })
   return mockFn(fetch)
 }

--- a/packages/eth-sdk/src/peripherals/fetchJson.ts
+++ b/packages/eth-sdk/src/peripherals/fetchJson.ts
@@ -1,0 +1,5 @@
+import got from 'got'
+
+export type FetchJson<T = any> = (url: string) => Promise<T>
+
+export const fetchJson: FetchJson = (url: string) => got(url).json()


### PR DESCRIPTION
- `CancellableRequest` is a little bit too large to pass stubbed in tests, so I wrapped `got` with a simpler API. We can reveal more got functionality it as we go.
- I ended up realizing it's good to have `got` underneath because cancelling requests and retries are two very useful features.