### PR TITLE
Fix Proxy handling for USDC and other Openzeppelin proxy contracts

### DIFF
--- a/.changeset/curvy-bobcats-clap.md
+++ b/.changeset/curvy-bobcats-clap.md
@@ -1,0 +1,5 @@
+---
+"@dethcrypto/eth-sdk": patch
+---
+
+Fix Proxy handling for USDC and other Openzeppelin proxy contracts

--- a/packages/eth-sdk/src/abi-management/detectProxy.test.ts
+++ b/packages/eth-sdk/src/abi-management/detectProxy.test.ts
@@ -8,8 +8,8 @@ import { Abi } from '../types'
 import {
   detectProxy,
   EIP1967_IMPLEMENTATION_STORAGE_SLOT,
-  ZEPPELIN_IMPLEMENTATION_STORAGE_SLOT,
   NUMBER_OF_KNOWN_STORAGE_SLOTS,
+  ZEPPELIN_IMPLEMENTATION_STORAGE_SLOT,
 } from './detectProxy'
 import type { RpcProvider } from './getRpcProvider'
 

--- a/packages/eth-sdk/src/abi-management/detectProxy.test.ts
+++ b/packages/eth-sdk/src/abi-management/detectProxy.test.ts
@@ -5,7 +5,12 @@ import { constants } from 'ethers'
 
 import { randomAddress } from '../../test/test-utils'
 import { Abi } from '../types'
-import { detectProxy, EIP1967_IMPLEMENTATION_STORAGE_SLOT } from './detectProxy'
+import {
+  detectProxy,
+  EIP1967_IMPLEMENTATION_STORAGE_SLOT,
+  ZEPPELIN_IMPLEMENTATION_STORAGE_SLOT,
+  NUMBER_OF_KNOWN_STORAGE_SLOTS,
+} from './detectProxy'
 import type { RpcProvider } from './getRpcProvider'
 
 describe(detectProxy.name, () => {
@@ -18,50 +23,6 @@ describe(detectProxy.name, () => {
     to: proxyAddr,
     data: new Interface(abiWithImplementationGetter).encodeFunctionData('implementation', []),
   }
-
-  it('detects .implementation getter', async () => {
-    const rpcProvider = {
-      call: mockFn<RpcProvider['call']>().resolvesToOnce(implAddr),
-      getCode: mockFn<RpcProvider['getCode']>().resolvesToOnce('0xfff'),
-      getStorageAt: mockFn<RpcProvider['getStorageAt']>(),
-    }
-
-    const actual = await detectProxy(proxyAddr, abiWithImplementationGetter, rpcProvider)
-
-    expect(actual).toEqual({
-      implAddress: implAddr,
-      isProxy: true,
-    })
-    expect(rpcProvider.call).toHaveBeenCalledWith([implementationCall])
-    expect(rpcProvider.getCode).toHaveBeenCalledWith([implAddr])
-  })
-
-  it('returns { isProxy: false } when .implementation returns nothing', async () => {
-    const rpcProvider = {
-      call: mockFn<RpcProvider['call']>().resolvesToOnce(constants.AddressZero),
-      getCode: mockFn<RpcProvider['getCode']>().resolvesToOnce('0xfff'),
-      getStorageAt: mockFn<RpcProvider['getStorageAt']>(),
-    }
-
-    const actual = await detectProxy(proxyAddr, abiWithImplementationGetter, rpcProvider)
-
-    expect(rpcProvider.getCode.calls.length).toEqual(0)
-    expect(rpcProvider.getStorageAt.calls.length).toEqual(0)
-    expect(actual).toEqual({ isProxy: false })
-  })
-
-  it('returns { isProxy: false } when address from .implementation has no contract code', async () => {
-    const rpcProvider = {
-      call: mockFn<RpcProvider['call']>().resolvesToOnce(implAddr),
-      getCode: mockFn<RpcProvider['getCode']>().given(implAddr).resolvesToOnce(constants.AddressZero),
-      getStorageAt: mockFn<RpcProvider['getStorageAt']>(),
-    }
-
-    const actual = await detectProxy(proxyAddr, abiWithImplementationGetter, rpcProvider)
-
-    expect(rpcProvider.getStorageAt.calls.length).toEqual(0)
-    expect(actual).toEqual({ isProxy: false })
-  })
 
   it('reads storage under EIP1967 implementation storage slot', async () => {
     const rpcProvider = {
@@ -79,6 +40,69 @@ describe(detectProxy.name, () => {
     expect(rpcProvider.getStorageAt).toHaveBeenCalledWith([proxyAddr, EIP1967_IMPLEMENTATION_STORAGE_SLOT])
   })
 
+  it('reads storage under OpenZeppelin implementation storage slot', async () => {
+    const rpcProvider = {
+      call: mockFn<RpcProvider['call']>(),
+      getCode: mockFn<RpcProvider['getCode']>().resolvesToOnce('0xfff'),
+      getStorageAt: mockFn<RpcProvider['getStorageAt']>()
+        .resolvesTo(constants.AddressZero)
+        .given(proxyAddr, ZEPPELIN_IMPLEMENTATION_STORAGE_SLOT)
+        .resolvesToOnce(implAddr),
+    }
+    const abi: Abi = []
+
+    const actual = await detectProxy(proxyAddr, abi, rpcProvider)
+
+    expect(actual).toEqual({ implAddress: implAddr, isProxy: true })
+    expect(rpcProvider.getStorageAt).toHaveBeenCalledWith([proxyAddr, EIP1967_IMPLEMENTATION_STORAGE_SLOT])
+    expect(rpcProvider.getStorageAt).toHaveBeenCalledWith([proxyAddr, ZEPPELIN_IMPLEMENTATION_STORAGE_SLOT])
+  })
+
+  it('detects .implementation getter', async () => {
+    const rpcProvider = {
+      call: mockFn<RpcProvider['call']>().resolvesToOnce(implAddr),
+      getCode: mockFn<RpcProvider['getCode']>().resolvesToOnce('0xfff'),
+      getStorageAt: mockFn<RpcProvider['getStorageAt']>().resolvesTo(constants.AddressZero),
+    }
+
+    const actual = await detectProxy(proxyAddr, abiWithImplementationGetter, rpcProvider)
+
+    expect(actual).toEqual({
+      implAddress: implAddr,
+      isProxy: true,
+    })
+    expect(rpcProvider.getStorageAt.calls.length).toEqual(NUMBER_OF_KNOWN_STORAGE_SLOTS)
+    expect(rpcProvider.call).toHaveBeenCalledWith([implementationCall])
+    expect(rpcProvider.getCode).toHaveBeenCalledWith([implAddr])
+  })
+
+  it('returns { isProxy: false } when .implementation returns nothing', async () => {
+    const rpcProvider = {
+      call: mockFn<RpcProvider['call']>().resolvesToOnce(constants.AddressZero),
+      getCode: mockFn<RpcProvider['getCode']>().resolvesToOnce('0xfff'),
+      getStorageAt: mockFn<RpcProvider['getStorageAt']>().resolvesTo(constants.AddressZero),
+    }
+
+    const actual = await detectProxy(proxyAddr, abiWithImplementationGetter, rpcProvider)
+
+    expect(rpcProvider.getCode.calls.length).toEqual(0)
+    expect(rpcProvider.getStorageAt.calls.length).toEqual(NUMBER_OF_KNOWN_STORAGE_SLOTS)
+    expect(actual).toEqual({ isProxy: false })
+  })
+
+  it('returns { isProxy: false } when address from .implementation has no contract code', async () => {
+    const rpcProvider = {
+      call: mockFn<RpcProvider['call']>().resolvesToOnce(implAddr),
+      getCode: mockFn<RpcProvider['getCode']>().given(implAddr).resolvesToOnce(constants.AddressZero),
+      getStorageAt: mockFn<RpcProvider['getStorageAt']>().resolvesTo(constants.AddressZero),
+    }
+
+    const actual = await detectProxy(proxyAddr, abiWithImplementationGetter, rpcProvider)
+
+    expect(rpcProvider.getStorageAt.calls.length).toEqual(NUMBER_OF_KNOWN_STORAGE_SLOTS)
+    expect(actual).toEqual({ isProxy: false })
+  })
+
   it('detects and calls custom implementation getters', async () => {
     const abi: Abi = [
       { name: 'currentImplementation', type: 'function', outputs: [{ type: 'address' }], stateMutability: 'view' },
@@ -94,7 +118,7 @@ describe(detectProxy.name, () => {
         .given({ to: proxyAddr, data: new Interface(abi).encodeFunctionData('currentImplementation', []) })
         .resolvesToOnce(implAddr),
       getCode: mockFn<RpcProvider['getCode']>().resolvesToOnce('0xfff'),
-      getStorageAt: mockFn<RpcProvider['getStorageAt']>().resolvesToOnce('0x0'),
+      getStorageAt: mockFn<RpcProvider['getStorageAt']>().resolvesTo(constants.AddressZero),
     }
 
     const actual = await detectProxy(proxyAddr, abi, rpcProvider)

--- a/packages/eth-sdk/src/abi-management/detectProxy.ts
+++ b/packages/eth-sdk/src/abi-management/detectProxy.ts
@@ -33,16 +33,24 @@ async function lookForImplementationAddr(address: Address, abi: Abi, provider: R
       }),
     )
 
+  // We check storage slot specified by EIP-1967 to hold implementation address.
+  // see https://eips.ethereum.org/EIPS/eip-1967
+  {
+    const stored = BigNumber.from(await provider.getStorageAt(address, EIP1967_IMPLEMENTATION_STORAGE_SLOT))
+    if (!stored.isZero()) return stored
+  }
+  // We check storage slot specified by openzeppelin to hold implementation address.
+  // see https://github.com/OpenZeppelin/openzeppelin-labs/blob/master/initializer_with_sol_editing/contracts/UpgradeabilityProxy.sol#L24
+  {
+    const stored = BigNumber.from(await provider.getStorageAt(address, ZEPPELIN_IMPLEMENTATION_STORAGE_SLOT))
+    if (!stored.isZero()) return stored
+  }
+
   // If there is an `.implementation` getter, we try to call it.
   const implementationGetter = abi.find((fragment) => fragment.name === 'implementation')
   if (implementationGetter && isPossibleImplementationGetter(implementationGetter)) {
     return call('implementation')
   }
-
-  // We check storage slot specified by EIP-1967 to hold implementation address.
-  // see https://eips.ethereum.org/EIPS/eip-1967
-  const stored = BigNumber.from(await provider.getStorageAt(address, EIP1967_IMPLEMENTATION_STORAGE_SLOT))
-  if (!stored.isZero()) return stored
 
   // Otherwise, we try shortest getter ending with "Implementation"
   const possibleImplementationGetters = abi.filter(isPossibleImplementationGetter)
@@ -56,6 +64,7 @@ async function lookForImplementationAddr(address: Address, abi: Abi, provider: R
 
 /** @internal */
 export const EIP1967_IMPLEMENTATION_STORAGE_SLOT = '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc'
+export const ZEPPELIN_IMPLEMENTATION_STORAGE_SLOT = '0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3'
 
 const isPossibleImplementationGetter = (frag: JsonFragment): frag is JsonFragment & { name: string } => {
   if (

--- a/packages/eth-sdk/src/abi-management/detectProxy.ts
+++ b/packages/eth-sdk/src/abi-management/detectProxy.ts
@@ -65,6 +65,7 @@ async function lookForImplementationAddr(address: Address, abi: Abi, provider: R
 /** @internal */
 export const EIP1967_IMPLEMENTATION_STORAGE_SLOT = '0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc'
 export const ZEPPELIN_IMPLEMENTATION_STORAGE_SLOT = '0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3'
+export const NUMBER_OF_KNOWN_STORAGE_SLOTS = 2
 
 const isPossibleImplementationGetter = (frag: JsonFragment): frag is JsonFragment & { name: string } => {
   if (


### PR DESCRIPTION
Fixes: https://github.com/dethcrypto/eth-sdk/issues/49

So the issue was that if you call `implementation()` on a USDC contract it reverts. It's because only admin can call it:
```
  function implementation() external view ifAdmin returns (address) {
    return _implementation();
  }
```
But fortunately there is a workaround. We already check for one standard storage slot. This is just another one. If we check for it before attempting to call a function - all good. No error