### PR TITLE
Allow duplicate contract names in different subtrees of a config

### DIFF
--- a/.changeset/small-ways-notice.md
+++ b/.changeset/small-ways-notice.md
@@ -1,6 +1,5 @@
 ---
 '@dethcrypto/eth-sdk': patch
-'test-e2e': patch
 ---
 
 Allow duplicate contract names in different subtrees of a config

--- a/.changeset/small-ways-notice.md
+++ b/.changeset/small-ways-notice.md
@@ -1,0 +1,6 @@
+---
+'@dethcrypto/eth-sdk': patch
+'test-e2e': patch
+---
+
+Allow duplicate contract names in different subtrees of a config

--- a/packages/eth-sdk/src/client/generateIndex.test.ts
+++ b/packages/eth-sdk/src/client/generateIndex.test.ts
@@ -1,0 +1,11 @@
+import { expect } from 'earljs'
+
+import { importedAbiIdentifier } from './generateIndex'
+
+describe(importedAbiIdentifier.name, () => {
+  it('converts a list of keys to an ABI identifier', () => {
+    const keys = ['mainnet', 'dai']
+    const identifier = importedAbiIdentifier(keys)
+    expect(identifier).toEqual('mainnetDaiAbi')
+  })
+})

--- a/packages/eth-sdk/src/client/generateIndex.ts
+++ b/packages/eth-sdk/src/client/generateIndex.ts
@@ -39,8 +39,8 @@ export function getContract(address: string, abi: object, defaultSigner: Signer)
   await fs.write(indexPath, index)
 }
 
-function importedAbiIdentifier(keys: string[]): string {
-  const name = normalizeName(keys[keys.length - 1]) + 'Abi'
+export function importedAbiIdentifier(keys: string[]): string {
+  const name = normalizeName([...keys, 'abi'].join('_'))
   return name[0].toLowerCase() + name.slice(1)
 }
 
@@ -75,7 +75,7 @@ function generateBody(nestedAddresses: NestedAddresses, keys: string[], topLevel
   for (const [key, addressOrNested] of Object.entries(nestedAddresses)) {
     if (typeof addressOrNested === 'string') {
       const address = addressOrNested
-      const abi = importedAbiIdentifier([key])
+      const abi = importedAbiIdentifier([...keys, key])
 
       body.push(`"${key}": getContract('${address}', ${abi}, defaultSigner) as types.${normalizeName(key)},`)
     } else {

--- a/packages/test-e2e/test/with-etherscan/sdk/esm/index.js
+++ b/packages/test-e2e/test/with-etherscan/sdk/esm/index.js
@@ -1,22 +1,22 @@
 import { Contract } from 'ethers';
-import daiAbi from '../../eth-sdk/abis/mainnet/tokens/dai.json';
-import mkrAbi from '../../eth-sdk/abis/mainnet/tokens/mkr.json';
-import uniswapAbi from '../../eth-sdk/abis/mainnet/uniswap.json';
-import proxyStandardStorageSlotAbi from '../../eth-sdk/abis/mainnet/proxies/proxyStandardStorageSlot.json';
-import proxyCustomImplementationAbi from '../../eth-sdk/abis/mainnet/proxies/proxyCustomImplementation.json';
+import mainnetTokensDaiAbi from '../../eth-sdk/abis/mainnet/tokens/dai.json';
+import mainnetTokensMkrAbi from '../../eth-sdk/abis/mainnet/tokens/mkr.json';
+import mainnetUniswapAbi from '../../eth-sdk/abis/mainnet/uniswap.json';
+import mainnetProxiesProxyStandardStorageSlotAbi from '../../eth-sdk/abis/mainnet/proxies/proxyStandardStorageSlot.json';
+import mainnetProxiesProxyCustomImplementationAbi from '../../eth-sdk/abis/mainnet/proxies/proxyCustomImplementation.json';
 export function getContract(address, abi, defaultSigner) {
     return new Contract(address, abi, defaultSigner);
 }
 export function getMainnetSdk(defaultSigner) {
     return {
         "tokens": {
-            "dai": getContract('0x6B175474E89094C44Da98b954EedeAC495271d0F', daiAbi, defaultSigner),
-            "mkr": getContract('0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2', mkrAbi, defaultSigner),
+            "dai": getContract('0x6B175474E89094C44Da98b954EedeAC495271d0F', mainnetTokensDaiAbi, defaultSigner),
+            "mkr": getContract('0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2', mainnetTokensMkrAbi, defaultSigner),
         },
-        "uniswap": getContract('0x1F98431c8aD98523631AE4a59f267346ea31F984', uniswapAbi, defaultSigner),
+        "uniswap": getContract('0x1F98431c8aD98523631AE4a59f267346ea31F984', mainnetUniswapAbi, defaultSigner),
         "proxies": {
-            "proxyStandardStorageSlot": getContract('0x1c5a768bdb10750f9007e33243fef5f3e094ad3a', proxyStandardStorageSlotAbi, defaultSigner),
-            "proxyCustomImplementation": getContract('0x3d9819210a31b4961b30ef54be2aed79b9c9cd3b', proxyCustomImplementationAbi, defaultSigner),
+            "proxyStandardStorageSlot": getContract('0x1c5a768bdb10750f9007e33243fef5f3e094ad3a', mainnetProxiesProxyStandardStorageSlotAbi, defaultSigner),
+            "proxyCustomImplementation": getContract('0x3d9819210a31b4961b30ef54be2aed79b9c9cd3b', mainnetProxiesProxyCustomImplementationAbi, defaultSigner),
         },
     };
 }


### PR DESCRIPTION
Fixes: https://github.com/dethcrypto/eth-sdk/issues/43
For config of a form:
```
{
  "a": {
    "dai": "..."
  },
  "b": {
    "dai": "..."
  }
}
```
We will not use fully qualified names to import Abi. Like:
```ts
import aDaiAbi from "..."
import bDaiAbi from "..."
```

Look at the changes to e2e package for examples.

I've decided to make this change patch as it's not breraking and we're not 1.0 yet, but feel free to change that.