### PR TITLE
Add HTTP 403 Forbidden to status codes to retry on

### DIFF
--- a/.changeset/mighty-knives-add.md
+++ b/.changeset/mighty-knives-add.md
@@ -1,0 +1,5 @@
+---
+'@dethcrypto/eth-sdk': patch
+---
+
+eth-sdk will now retry up to 2 times on HTTP403 Forbidden when fetching ABI

--- a/packages/eth-sdk/src/peripherals/fetchJson.ts
+++ b/packages/eth-sdk/src/peripherals/fetchJson.ts
@@ -1,5 +1,15 @@
-import got from 'got'
+import got, { RequiredRetryOptions } from 'got'
 
 export type FetchJson<T = any> = (url: string) => Promise<T>
 
-export const fetchJson: FetchJson = (url: string) => got(url).json()
+const retryOptions: Partial<RequiredRetryOptions> = {
+  limit: 2,
+  statusCodes: [
+    // defaults
+    408, 413, 429, 500, 502, 503, 504, 521, 522, 524,
+    // added
+    403,
+  ],
+}
+
+export const fetchJson: FetchJson = (url: string) => got(url, { retry: retryOptions }).json()


### PR DESCRIPTION
eth-sdk will now retry up to 2 times on HTTP403 Forbidden when fetching ABI
