### PR TITLE
Docs: Add Avalanche Network ID Keys

### DIFF
--- a/packages/eth-sdk/README.md
+++ b/packages/eth-sdk/README.md
@@ -167,7 +167,8 @@ Predefined network identifiers are:
 "bscTestnet"         "heco"               "hecoTestnet"
 "opera"              "ftmTestnet"         "optimism"
 "optimismKovan"      "polygon"            "polygonMumbai"
-"arbitrumOne"        "arbitrumTestnet"
+"arbitrumOne"        "arbitrumTestnet"    "avalanche"
+"fuji"
 ```
 
 You can use other networks, but you will need to configure Etherscan URLs for them in [`etherscanURLs`](#etherscanurls)


### PR DESCRIPTION
`eth-sdk` currently ships with Avalanche mainnet/testnet support, however the keys were not indicated in the README.